### PR TITLE
Add RPC call gettxout

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -155,6 +155,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "checkkernel", 1 },
     { "submitblock", 1 },
     { "gettxout", 1 },
+    { "gettxout", 2 },
 };
 
 class CRPCConvertTable

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -154,6 +154,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "checkkernel", 0 },
     { "checkkernel", 1 },
     { "submitblock", 1 },
+    { "gettxout", 1 },
 };
 
 class CRPCConvertTable

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -245,6 +245,7 @@ static const CRPCCommand vRPCCommands[] =
     { "validateaddress",        &validateaddress,        true,      false,     false },
     { "validatepubkey",         &validatepubkey,         true,      false,     false },
     { "verifymessage",          &verifymessage,          false,     false,     false },
+    { "gettxout",               &gettxout,               false,     false,     false },
 
 #ifdef ENABLE_WALLET
     { "getmininginfo",          &getmininginfo,          true,      false,     false },

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -144,6 +144,7 @@ extern json_spirit::Value listaddressgroupings(const json_spirit::Array& params,
 extern json_spirit::Value listaccounts(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value listsinceblock(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value gettransaction(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value gettxout(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value backupwallet(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value keypoolrefill(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value walletpassphrase(const json_spirit::Array& params, bool fHelp);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1257,7 +1257,6 @@ Value gettransaction(const Array& params, bool fHelp)
     return entry;
 }
 
-
 Value backupwallet(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
@@ -1553,7 +1552,7 @@ Value makekeypair(const Array& params, bool fHelp)
     string strPrefix = "";
     if (params.size() > 0)
         strPrefix = params[0].get_str();
- 
+
     CKey key;
     key.MakeNewKey(false);
 


### PR DESCRIPTION
RPC call: gettxout
The gettxout RPC returns details about a transaction output. Only unspent transaction outputs (UTXOs) are guaranteed to be available.

Parameter 1—the TXID of the output to get
Parameter 2—the output index number (vout) of the output to get
Parameter 3—whether to display unconfirmed outputs from the memory pool

Result—a description of the output