### PR TITLE
Support openssl-1.1

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -11,6 +11,7 @@
 #include "version.h"
 
 #include <openssl/bn.h>
+#include <openssl/opensslv.h>  // For using openssl 1.0 and 1.1 branches.
 
 #include <stdexcept>
 #include <vector>
@@ -52,38 +53,83 @@ public:
     bool operator!() { return (pctx == NULL); }
 };
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 
-/** C++ wrapper for BIGNUM (OpenSSL bignum) */
+//C++ wrapper for BIGNUM (OpenSSL 1.0 bignum)
 class CBigNum : public BIGNUM
 {
+
+#else
+//C++ wrapper for BIGNUM (OpenSSL 1.1 bignum)
+class CBigNum
+{
+protected:
+    BIGNUM *bn;
+
+    void CBigNum_init()
+    {
+        bn = BN_secure_new();
+    }
+
+#endif
+
 public:
     CBigNum()
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_init(this);
+#else
+        CBigNum_init();
+#endif
     }
 
     CBigNum(const CBigNum& b)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_init(this);
         if (!BN_copy(this, &b))
         {
             BN_clear_free(this);
             throw bignum_error("CBigNum::CBigNum(const CBigNum&) : BN_copy failed");
         }
+#else
+        CBigNum_init();
+        if (!BN_copy(bn, &b))
+        {
+            BN_clear_free(bn);
+            throw bignum_error("CBigNum::CBigNum(const CBigNum&) : BN_copy failed");
+        }
+#endif
     }
 
     CBigNum& operator=(const CBigNum& b)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_copy(this, &b))
+#else
+        if (!BN_copy(bn, &b))
+#endif
             throw bignum_error("CBigNum::operator= : BN_copy failed");
         return (*this);
     }
 
     ~CBigNum()
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_clear_free(this);
+#else
+        BN_clear_free(bn);
+#endif
     }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    BIGNUM *operator &() const
+    {
+        return bn;
+    }
+#endif
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     //CBigNum(char n) is not portable.  Use 'signed char' or 'unsigned char'.
     CBigNum(signed char n)        { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
     CBigNum(short n)              { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
@@ -96,10 +142,28 @@ public:
     CBigNum(unsigned long n)      { BN_init(this); setulong(n); }
     CBigNum(unsigned long long n) { BN_init(this); setuint64(n); }
     explicit CBigNum(uint256 n)   { BN_init(this); setuint256(n); }
+#else
+    //CBigNum(char n) is not portable.  Use 'signed char' or 'unsigned char'.
+    CBigNum(signed char n)        { CBigNum_init(); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(short n)              { CBigNum_init(); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(int n)                { CBigNum_init(); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(long n)               { CBigNum_init(); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(long long n)          { CBigNum_init(); setint64(n); }
+    CBigNum(unsigned char n)      { CBigNum_init(); setulong(n); }
+    CBigNum(unsigned short n)     { CBigNum_init(); setulong(n); }
+    CBigNum(unsigned int n)       { CBigNum_init(); setulong(n); }
+    CBigNum(unsigned long n)      { CBigNum_init(); setulong(n); }
+    CBigNum(unsigned long long n) { CBigNum_init(); setuint64(n); }
+    explicit CBigNum(uint256 n)   { CBigNum_init(); setuint256(n); }
+#endif
 
     explicit CBigNum(const std::vector<unsigned char>& vch)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_init(this);
+#else
+        CBigNum_init();
+#endif
         setvch(vch);
     }
 
@@ -133,30 +197,52 @@ public:
      * @return the size
      */
     int bitSize() const{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         return  BN_num_bits(this);
+#else
+        return  BN_num_bits(bn);
+#endif
     }
 
 
     void setulong(unsigned long n)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_set_word(this, n))
             throw bignum_error("CBigNum conversion from unsigned long : BN_set_word failed");
+#else
+        if (!BN_set_word(bn, n))
+            throw bignum_error("CBigNum conversion from unsigned long : BN_set_word failed");
+#endif
     }
 
     unsigned long getulong() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         return BN_get_word(this);
+#else
+        return BN_get_word(bn);
+#endif
     }
 
     unsigned int getuint() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         return BN_get_word(this);
+#else
+        return BN_get_word(bn);
+#endif
     }
 
     int getint() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         unsigned long n = BN_get_word(this);
         if (!BN_is_negative(this))
+#else
+        unsigned long n = BN_get_word(bn);
+        if (!BN_is_negative(bn))
+#endif
             return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::max() : n);
         else
             return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::min() : -(int)n);
@@ -202,16 +288,30 @@ public:
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize) & 0xff;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_mpi2bn(pch, p - pch, this);
+#else
+        BN_mpi2bn(pch, p - pch, bn);
+#endif
+
     }
 
     uint64_t getuint64()
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         unsigned int nSize = BN_bn2mpi(this, NULL);
+#else
+        unsigned int nSize = BN_bn2mpi(bn, NULL);
+#endif
         if (nSize < 4)
             return 0;
+
         std::vector<unsigned char> vch(nSize);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_bn2mpi(this, &vch[0]);
+#else
+        BN_bn2mpi(bn, &vch[0]);
+#endif
         if (vch.size() > 4)
             vch[4] &= 0x7f;
         uint64_t n = 0;
@@ -244,7 +344,11 @@ public:
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize) & 0xff;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_mpi2bn(pch, p - pch, this);
+#else
+        BN_mpi2bn(pch, p - pch, bn);
+#endif
     }
 
     void setuint256(uint256 n)
@@ -272,16 +376,28 @@ public:
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize >> 0) & 0xff;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_mpi2bn(pch, p - pch, this);
+#else
+        BN_mpi2bn(pch, p - pch, bn);
+#endif
     }
 
     uint256 getuint256() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         unsigned int nSize = BN_bn2mpi(this, NULL);
+#else
+        unsigned int nSize = BN_bn2mpi(bn, NULL);
+#endif
         if (nSize < 4)
             return 0;
         std::vector<unsigned char> vch(nSize);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_bn2mpi(this, &vch[0]);
+#else
+        BN_bn2mpi(bn, &vch[0]);
+#endif
         if (vch.size() > 4)
             vch[4] &= 0x7f;
         uint256 n = 0;
@@ -303,16 +419,28 @@ public:
         vch2[3] = (nSize >> 0) & 0xff;
         // swap data to big endian
         reverse_copy(vch.begin(), vch.end(), vch2.begin() + 4);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_mpi2bn(&vch2[0], vch2.size(), this);
+#else
+        BN_mpi2bn(&vch2[0], vch2.size(), bn);
+#endif
     }
 
     std::vector<unsigned char> getvch() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         unsigned int nSize = BN_bn2mpi(this, NULL);
+#else
+        unsigned int nSize = BN_bn2mpi(bn, NULL);
+#endif
         if (nSize <= 4)
             return std::vector<unsigned char>();
         std::vector<unsigned char> vch(nSize);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_bn2mpi(this, &vch[0]);
+#else
+        BN_bn2mpi(bn, &vch[0]);
+#endif
         vch.erase(vch.begin(), vch.begin() + 4);
         reverse(vch.begin(), vch.end());
         return vch;
@@ -326,16 +454,28 @@ public:
         if (nSize >= 1) vch[4] = (nCompact >> 16) & 0xff;
         if (nSize >= 2) vch[5] = (nCompact >> 8) & 0xff;
         if (nSize >= 3) vch[6] = (nCompact >> 0) & 0xff;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_mpi2bn(&vch[0], vch.size(), this);
+#else
+        BN_mpi2bn(&vch[0], vch.size(), bn);
+#endif
         return *this;
     }
 
     unsigned int GetCompact() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         unsigned int nSize = BN_bn2mpi(this, NULL);
+#else
+        unsigned int nSize = BN_bn2mpi(bn, NULL);
+#endif
         std::vector<unsigned char> vch(nSize);
         nSize -= 4;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_bn2mpi(this, &vch[0]);
+#else
+        BN_bn2mpi(bn, &vch[0]);
+#endif
         unsigned int nCompact = nSize << 24;
         if (nSize >= 1) nCompact |= (vch[4] << 16);
         if (nSize >= 2) nCompact |= (vch[5] << 8);
@@ -379,21 +519,46 @@ public:
         CBigNum bnBase = nBase;
         CBigNum bn0 = 0;
         std::string str;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         CBigNum bn = *this;
         BN_set_negative(&bn, false);
+#else
+        CBigNum bn1 = *this;
+        BN_set_negative(&bn1, false);
+#endif
         CBigNum dv;
         CBigNum rem;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (BN_cmp(&bn, &bn0) == 0)
+#else
+        if (BN_cmp(&bn1, &bn0) == 0)
+#endif
             return "0";
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         while (BN_cmp(&bn, &bn0) > 0)
+#else
+        while (BN_cmp(&bn1, &bn0) > 0)
+#endif
         {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             if (!BN_div(&dv, &rem, &bn, &bnBase, pctx))
+#else
+            if (!BN_div(&dv, &rem, &bn1, &bnBase, pctx))
+#endif
                 throw bignum_error("CBigNum::ToString() : BN_div failed");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             bn = dv;
+#else
+            bn1 = dv;
+#endif
             unsigned int c = rem.getulong();
             str += "0123456789abcdef"[c];
         }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (BN_is_negative(this))
+#else
+        if (BN_is_negative(bn))
+#endif
             str += "-";
         reverse(str.begin(), str.end());
         return str;
@@ -440,9 +605,15 @@ public:
     CBigNum pow(const CBigNum& e) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_exp(&ret, this, &e, pctx))
             throw bignum_error("CBigNum::pow : BN_exp failed");
         return ret;
+#else
+        if (!BN_exp(&ret, bn, &e, pctx))
+            throw bignum_error("CBigNum::pow : BN_exp failed");
+        return ret;
+#endif
     }
 
     /**
@@ -453,10 +624,15 @@ public:
     CBigNum mul_mod(const CBigNum& b, const CBigNum& m) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_mod_mul(&ret, this, &b, &m, pctx))
             throw bignum_error("CBigNum::mul_mod : BN_mod_mul failed");
-        
         return ret;
+#else
+        if (!BN_mod_mul(&ret, bn, &b, &m, pctx))
+            throw bignum_error("CBigNum::mul_mod : BN_mod_mul failed");
+        return ret;
+#endif
     }
 
     /**
@@ -474,7 +650,11 @@ public:
             if (!BN_mod_exp(&ret, &inv, &posE, &m, pctx))
                 throw bignum_error("CBigNum::pow_mod: BN_mod_exp failed on negative exponent");
         }else
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             if (!BN_mod_exp(&ret, this, &e, &m, pctx))
+#else
+            if (!BN_mod_exp(&ret, bn, &e, &m, pctx))
+#endif
                 throw bignum_error("CBigNum::pow_mod : BN_mod_exp failed");
 
         return ret;
@@ -489,7 +669,11 @@ public:
     CBigNum inverse(const CBigNum& m) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_mod_inverse(&ret, this, &m, pctx))
+#else
+        if (!BN_mod_inverse(&ret, bn, &m, pctx))
+#endif
             throw bignum_error("CBigNum::inverse*= :BN_mod_inverse");
         return ret;
     }
@@ -515,7 +699,11 @@ public:
     CBigNum gcd( const CBigNum& b) const{
         CAutoBN_CTX pctx;
         CBigNum ret;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_gcd(&ret, this, &b, pctx))
+#else
+        if (!BN_gcd(&ret, bn, &b, pctx))
+#endif
             throw bignum_error("CBigNum::gcd*= :BN_gcd");
         return ret;
     }
@@ -528,7 +716,11 @@ public:
     */
     bool isPrime(const int checks=BN_prime_checks) const {
         CAutoBN_CTX pctx;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         int ret = BN_is_prime(this, checks, NULL, pctx, NULL);
+#else
+        int ret = BN_is_prime_ex(bn, checks, pctx, NULL);
+#endif
         if(ret < 0){
             throw bignum_error("CBigNum::isPrime :BN_is_prime");
         }
@@ -536,18 +728,30 @@ public:
     }
 
     bool isOne() const {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         return BN_is_one(this);
+#else
+        return BN_is_one(bn);
+#endif
     }
 
 
     bool operator!() const
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         return BN_is_zero(this);
+#else
+        return BN_is_zero(bn);
+#endif
     }
 
     CBigNum& operator+=(const CBigNum& b)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_add(this, this, &b))
+#else
+        if (!BN_add(bn, bn, &b))
+#endif
             throw bignum_error("CBigNum::operator+= : BN_add failed");
         return *this;
     }
@@ -561,7 +765,11 @@ public:
     CBigNum& operator*=(const CBigNum& b)
     {
         CAutoBN_CTX pctx;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_mul(this, this, &b, pctx))
+#else
+        if (!BN_mul(bn, bn, &b, pctx))
+#endif
             throw bignum_error("CBigNum::operator*= : BN_mul failed");
         return *this;
     }
@@ -580,7 +788,11 @@ public:
 
     CBigNum& operator<<=(unsigned int shift)
     {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_lshift(this, this, shift))
+#else
+        if (!BN_lshift(bn, bn, shift))
+#endif
             throw bignum_error("CBigNum:operator<<= : BN_lshift failed");
         return *this;
     }
@@ -591,13 +803,20 @@ public:
         //   if built on ubuntu 9.04 or 9.10, probably depends on version of OpenSSL
         CBigNum a = 1;
         a <<= shift;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (BN_cmp(&a, this) > 0)
+#else
+        if (BN_cmp(&a, bn) > 0)
+#endif
         {
             *this = 0;
             return *this;
         }
-
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_rshift(this, this, shift))
+#else
+        if (!BN_rshift(bn, bn, shift))
+#endif
             throw bignum_error("CBigNum:operator>>= : BN_rshift failed");
         return *this;
     }
@@ -606,7 +825,11 @@ public:
     CBigNum& operator++()
     {
         // prefix operator
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_add(this, this, BN_value_one()))
+#else
+        if (!BN_add(bn, bn, BN_value_one()))
+#endif
             throw bignum_error("CBigNum::operator++ : BN_add failed");
         return *this;
     }
@@ -623,7 +846,11 @@ public:
     {
         // prefix operator
         CBigNum r;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (!BN_sub(&r, this, BN_value_one()))
+#else
+        if (!BN_sub(&r, bn, BN_value_one()))
+#endif
             throw bignum_error("CBigNum::operator-- : BN_sub failed");
         *this = r;
         return *this;

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 #include <boost/foreach.hpp>
+#include <openssl/opensslv.h>     // For using openssl 1.0 and 1.1 branches.
 #include <openssl/aes.h>
 #include <openssl/evp.h>
 #ifdef WIN32
@@ -73,15 +74,28 @@ bool CCrypter::Encrypt(const CKeyingMaterial& vchPlaintext, std::vector<unsigned
     int nCLen = nLen + AES_BLOCK_SIZE, nFLen = 0;
     vchCiphertext = std::vector<unsigned char> (nCLen);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX ctx;
+#else
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+#endif
 
     bool fOk = true;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX_init(&ctx);
     if (fOk) fOk = EVP_EncryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
     if (fOk) fOk = EVP_EncryptUpdate(&ctx, &vchCiphertext[0], &nCLen, &vchPlaintext[0], nLen);
     if (fOk) fOk = EVP_EncryptFinal_ex(&ctx, (&vchCiphertext[0])+nCLen, &nFLen);
     EVP_CIPHER_CTX_cleanup(&ctx);
+#else
+    EVP_CIPHER_CTX_init(ctx);
+    if (fOk) fOk = EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+    if (fOk) fOk = EVP_EncryptUpdate(ctx, &vchCiphertext[0], &nCLen, &vchPlaintext[0], nLen);
+    if (fOk) fOk = EVP_EncryptFinal_ex(ctx, (&vchCiphertext[0])+nCLen, &nFLen);
+    EVP_CIPHER_CTX_free(ctx);
+#endif
+
 
     if (!fOk) return false;
 
@@ -100,15 +114,27 @@ bool CCrypter::Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingM
 
     vchPlaintext = CKeyingMaterial(nPLen);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX ctx;
+#else
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+#endif
 
     bool fOk = true;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX_init(&ctx);
     if (fOk) fOk = EVP_DecryptInit_ex(&ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
     if (fOk) fOk = EVP_DecryptUpdate(&ctx, &vchPlaintext[0], &nPLen, &vchCiphertext[0], nLen);
     if (fOk) fOk = EVP_DecryptFinal_ex(&ctx, (&vchPlaintext[0])+nPLen, &nFLen);
     EVP_CIPHER_CTX_cleanup(&ctx);
+#else
+    EVP_CIPHER_CTX_init(ctx);
+    if (fOk) fOk = EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, chKey, chIV);
+    if (fOk) fOk = EVP_DecryptUpdate(ctx, &vchPlaintext[0], &nPLen, &vchCiphertext[0], nLen);
+    if (fOk) fOk = EVP_DecryptFinal_ex(ctx, (&vchPlaintext[0])+nPLen, &nFLen);
+    EVP_CIPHER_CTX_free(ctx);
+#endif
 
     if (!fOk) return false;
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <openssl/opensslv.h>  // For using openssl 1.0 and 1.1 branches.
 #include <openssl/bn.h>
 #include <openssl/ecdsa.h>
 #include <openssl/rand.h>
@@ -74,6 +75,14 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     int n = 0;
     int i = recid / 2;
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    const BIGNUM *r;
+    const BIGNUM *s;
+    r = BN_new();
+    s = BN_new();
+    ECDSA_SIG_get0(ecsig, &r, &s);
+#endif
+
     const EC_GROUP *group = EC_KEY_get0_group(eckey);
     if ((ctx = BN_CTX_new()) == NULL) { ret = -1; goto err; }
     BN_CTX_start(ctx);
@@ -82,7 +91,11 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     x = BN_CTX_get(ctx);
     if (!BN_copy(x, order)) { ret=-1; goto err; }
     if (!BN_mul_word(x, i)) { ret=-1; goto err; }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!BN_add(x, x, ecsig->r)) { ret=-1; goto err; }
+#else
+    if (!BN_add(x, x, r)) { ret=-1; goto err; }
+#endif
     field = BN_CTX_get(ctx);
     if (!EC_GROUP_get_curve_GFp(group, field, NULL, NULL, ctx)) { ret=-2; goto err; }
     if (BN_cmp(x, field) >= 0) { ret=0; goto err; }
@@ -103,9 +116,17 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     if (!BN_zero(zero)) { ret=-1; goto err; }
     if (!BN_mod_sub(e, zero, e, order, ctx)) { ret=-1; goto err; }
     rr = BN_CTX_get(ctx);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!BN_mod_inverse(rr, ecsig->r, order, ctx)) { ret=-1; goto err; }
+#else
+    if (!BN_mod_inverse(rr, r, order, ctx)) { ret=-1; goto err; }
+#endif
     sor = BN_CTX_get(ctx);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!BN_mod_mul(sor, ecsig->s, rr, order, ctx)) { ret=-1; goto err; }
+#else
+    if (!BN_mod_mul(sor, s, rr, order, ctx)) { ret=-1; goto err; }
+#endif
     eor = BN_CTX_get(ctx);
     if (!BN_mod_mul(eor, e, rr, order, ctx)) { ret=-1; goto err; }
     if (!EC_POINT_mul(group, Q, eor, R, sor, ctx)) { ret=-2; goto err; }
@@ -150,6 +171,7 @@ public:
 
     void SetSecretBytes(const unsigned char vch[32]) {
         bool ret;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BIGNUM bn;
         BN_init(&bn);
         ret = BN_bin2bn(vch, 32, &bn);
@@ -157,6 +179,15 @@ public:
         ret = EC_KEY_regenerate_key(pkey, &bn);
         assert(ret);
         BN_clear_free(&bn);
+#else
+        BIGNUM *bn;
+        bn = BN_secure_new();
+        ret = BN_bin2bn(vch, 32, bn);
+        assert(ret);
+        ret = EC_KEY_regenerate_key(pkey, bn);
+        assert(ret);
+        BN_clear_free(bn);
+#endif
     }
 
     void GetPrivKey(CPrivKey &privkey, bool fCompressed) {
@@ -212,10 +243,25 @@ public:
         BIGNUM *halforder = BN_CTX_get(ctx);
         EC_GROUP_get_order(group, order, ctx);
         BN_rshift1(halforder, order);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (BN_cmp(sig->s, halforder) > 0) {
             // enforce low S values, by negating the value (modulo the order) if above order/2.
             BN_sub(sig->s, order, sig->s);
         }
+#else
+        const BIGNUM *r;
+        const BIGNUM *s;
+        r = BN_secure_new();
+        s = BN_secure_new();
+        ECDSA_SIG_get0(sig, &r, &s);
+        BIGNUM *s1;
+        s1 = BN_secure_new();
+        BN_copy(s1,s);
+        if (BN_cmp(s, halforder) > 0) {
+            // enforce low S values, by negating the value (modulo the order) if above order/2.
+            BN_sub(s1, order, s1);
+        }
+#endif
         BN_CTX_end(ctx);
         BN_CTX_free(ctx);
         unsigned int nSize = ECDSA_size(pkey);
@@ -240,8 +286,18 @@ public:
         if (sig==NULL)
             return false;
         memset(p64, 0, 64);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         int nBitsR = BN_num_bits(sig->r);
         int nBitsS = BN_num_bits(sig->s);
+#else
+        const BIGNUM *r;
+        const BIGNUM *s;
+        r = BN_secure_new();
+        s = BN_secure_new();
+        ECDSA_SIG_get0(sig, &r, &s);
+        int nBitsR = BN_num_bits(r);
+        int nBitsS = BN_num_bits(s);
+#endif
         if (nBitsR <= 256 && nBitsS <= 256) {
             CPubKey pubkey;
             GetPubKey(pubkey, true);
@@ -258,8 +314,13 @@ public:
                 }
             }
             assert(fOk);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             BN_bn2bin(sig->r,&p64[32-(nBitsR+7)/8]);
             BN_bn2bin(sig->s,&p64[64-(nBitsS+7)/8]);
+#else
+            BN_bn2bin(r,&p64[32-(nBitsR+7)/8]);
+            BN_bn2bin(s,&p64[64-(nBitsS+7)/8]);
+#endif
         }
         ECDSA_SIG_free(sig);
         return fOk;
@@ -274,8 +335,20 @@ public:
         if (rec<0 || rec>=3)
             return false;
         ECDSA_SIG *sig = ECDSA_SIG_new();
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_bin2bn(&p64[0],  32, sig->r);
         BN_bin2bn(&p64[32], 32, sig->s);
+#else
+        const BIGNUM *r;
+        const BIGNUM *s;
+        r = BN_secure_new();
+        s = BN_secure_new();
+        BIGNUM *r1;
+        BIGNUM *s1;
+        ECDSA_SIG_get0(sig, &r, &s);
+        BN_bin2bn(&p64[0],  32, r1);
+        BN_bin2bn(&p64[32], 32, s1);
+#endif
         bool ret = ECDSA_SIG_recover_key_GFp(pkey, sig, (unsigned char*)&hash, sizeof(hash), rec, 0) == 1;
         ECDSA_SIG_free(sig);
         return ret;


### PR DESCRIPTION
Hello!

Without this patch (taken from [eMark](../../../emarkproject/eMark/commit/9929375df86cc2bfb093bb54102cc2df09dbed6d)) bitbayd won't build with openssl-1.1 and newer.